### PR TITLE
Add full title to page

### DIFF
--- a/index.idyll
+++ b/index.idyll
@@ -1,4 +1,4 @@
-[meta title:"pac_learning" description:"An illustration of PAC Learning and why ML models can fail in deployment." /]
+[meta title:"PAC Learning; Or: Why We Should (and Shouldn't) Trust Machine Learning" description:"An illustration of PAC Learning and why ML models can fail in deployment." /]
 
 [Header
   fullWidth:true


### PR DESCRIPTION
This is a minor change that ensures the output has a `<title>` tag giving the full paper title. As we begin to automate parts of the workflow this will help.